### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,6 +45,7 @@ my $builder = $class->new(
 		'Test::Exception'      => 0,
 	  'Test::FailWarnings'   => 0,
 		'Test::Git'            => 0,
+		'Test::Requires::Git'  => 1.005,
 		'Test::More'           => 0.94,
 	},
 	requires             =>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile
   'PREREQ_PM' => {
                    'App::GitHooks' => 0,
                    'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::Exception' => 0,
                    'Capture::Tiny' => 0,
                    'Test::FailWarnings' => 0,

--- a/t/01-git_version.t
+++ b/t/01-git_version.t
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
-has_git();
+test_requires_git();
 
 plan( tests => 2 );
 

--- a/t/10-run_pre_push.t
+++ b/t/10-run_pre_push.t
@@ -8,6 +8,7 @@ use warnings;
 use Capture::Tiny;
 use Test::Exception;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 use App::GitHooks::Test qw( ok_add_files ok_setup_repository );
@@ -19,7 +20,7 @@ use App::GitHooks::Test qw( ok_add_files ok_setup_repository );
 
 # The plugin relies on the pre-push hook, which is only available as of git
 # v1.8.2.
-has_git( '1.8.2' );
+test_requires_git( '1.8.2' );
 
 # List of tests to perform.
 my $tests =


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
